### PR TITLE
SD card mounting, attackmode and payload config through settings.toml, LED keyword for duckyscript

### DIFF
--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -5,6 +5,7 @@ import usb_hid
 import sdcardio
 import busio
 import os
+import state
 
 program_pin = digitalio.DigitalInOut(board.GP0)
 program_pin.direction = digitalio.Direction.INPUT
@@ -14,6 +15,7 @@ print("Boot.py: Starting...")
 
 payload_name = os.getenv("PAYLOAD_NAME")
 payload_dir = os.getenv("PAYLOAD_DIRECTORY")
+attack_mode = os.getenv("ATTACK_MODE")
 
 print("PAYLOAD DIRECTORY:", repr(payload_dir))
 print("PAYLOAD NAME:", repr(payload_name))
@@ -44,14 +46,17 @@ usb_hid.enable((usb_hid.Device.KEYBOARD,))
 
 if not program_pin.value:
     print("Boot.py: Entering programming mode")
+    state.programming_mode = False
     storage.remount("/", readonly=True)
-
 else:
     print("Boot.py: Entering payload mode")
-    storage.disable_usb_drive()
+    state.programming_mode = True
+    if attack_mode != "storage":
+        storage.disable_usb_drive()
+    else:
+        storage.remount("/", readonly=True)
 
     try:
-        # storage.remount("/", readonly=False)
         if usb_hid.devices:
             print("Boot.py: HID keyboard enabled successfully")
         else:

--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -2,12 +2,41 @@ import board
 import digitalio
 import storage
 import usb_hid
+import sdcardio
+import busio
+import os
 
 program_pin = digitalio.DigitalInOut(board.GP0)
 program_pin.direction = digitalio.Direction.INPUT
 program_pin.pull = digitalio.Pull.UP
 
 print("Boot.py: Starting...")
+
+payload_name = os.getenv("PAYLOAD_NAME")
+payload_dir = os.getenv("PAYLOAD_DIRECTORY")
+
+print("PAYLOAD DIRECTORY:", repr(payload_dir))
+print("PAYLOAD NAME:", repr(payload_name))
+print("PAYLOAD DIR:", os.listdir(payload_dir))
+
+print("Boot.py: Mounting SD")
+
+SD_AVAILABLE = False
+
+try:
+    spi = busio.SPI(board.GP2, MOSI=board.GP3, MISO=board.GP4)
+    cs = board.GP5
+
+    sd = sdcardio.SDCard(spi, cs)
+    vfs = storage.VfsFat(sd)
+    storage.mount(vfs, "/sd")
+
+    SD_AVAILABLE = True
+    print("SD card mounted")
+
+except (OSError, RuntimeError) as e:
+    print("SD Card mount failure :", e)
+
 print("Boot.py: Configuring USB HID")
 # HID is enabled even in programming mode because that makes it easier to debug.
 usb_hid.enable((usb_hid.Device.KEYBOARD,))

--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -5,7 +5,7 @@ import usb_hid
 import sdcardio
 import busio
 import os
-import state
+import microcontroller
 
 program_pin = digitalio.DigitalInOut(board.GP0)
 program_pin.direction = digitalio.Direction.INPUT
@@ -13,17 +13,9 @@ program_pin.pull = digitalio.Pull.UP
 
 print("Boot.py: Starting...")
 
-payload_name = os.getenv("PAYLOAD_NAME")
-payload_dir = os.getenv("PAYLOAD_DIRECTORY")
 attack_mode = os.getenv("ATTACK_MODE")
 
-print("PAYLOAD DIRECTORY:", repr(payload_dir))
-print("PAYLOAD NAME:", repr(payload_name))
-print("PAYLOAD DIR:", os.listdir(payload_dir))
-
 print("Boot.py: Mounting SD")
-
-SD_AVAILABLE = False
 
 try:
     spi = busio.SPI(board.GP2, MOSI=board.GP3, MISO=board.GP4)
@@ -33,7 +25,6 @@ try:
     vfs = storage.VfsFat(sd)
     storage.mount(vfs, "/sd")
 
-    SD_AVAILABLE = True
     print("SD card mounted")
 
 except (OSError, RuntimeError) as e:
@@ -43,14 +34,17 @@ print("Boot.py: Configuring USB HID")
 # HID is enabled even in programming mode because that makes it easier to debug.
 usb_hid.enable((usb_hid.Device.KEYBOARD,))
 
+programming_mode = not program_pin.value
 
-if not program_pin.value:
+# dont rewrite to nvm unless necessary
+if microcontroller.nvm[0] != programming_mode:
+    microcontroller.nvm[0] = 1 if programming_mode else 0
+
+if programming_mode:
     print("Boot.py: Entering programming mode")
-    state.programming_mode = False
     storage.remount("/", readonly=True)
 else:
     print("Boot.py: Entering payload mode")
-    state.programming_mode = True
     if attack_mode != "storage":
         storage.disable_usb_drive()
     else:

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -2,6 +2,7 @@
 import os
 import digitalio
 import board
+import state
 
 print("Main.py: Starting up...")
 # Setup LED
@@ -26,7 +27,7 @@ from adafruit_logging import FileHandler
 
 logger = logging.getLogger("compiler.py")
 logger.setLevel(logging.DEBUG)
-programming_mode = True
+programming_mode = state.programming_mode
 
 try:
     LOG_FILE_PATH = "/debug.log"
@@ -35,7 +36,6 @@ try:
     import adafruit_datetime as datetime
 
     logger.info(f"BOOT {datetime.datetime.now()}")
-    programming_mode = False
 except:
     print("Debug mode active...")
     print("Logging to file is disabled.")
@@ -404,6 +404,12 @@ try:
 
                 elif command.startswith("$"):
                     out.append(lambda l=line: self.reassign(l))
+
+                elif command.startswith("LED"):
+                    if line[1] == "1":
+                        status_led.value = True
+                    if line[1] == "0":
+                        status_led.value = True
 
             return out
 

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -406,9 +406,9 @@ try:
                     out.append(lambda l=line: self.reassign(l))
 
                 elif command == "LED_ON":
-                    out.append(lambda: self.led(True))
+                    out.append(lambda: self.set_led(True))
                 elif command == "LED_OFF":
-                    out.append(lambda: self.led(False))
+                    out.append(lambda: self.set_led(False))
 
             return out
 
@@ -688,7 +688,7 @@ try:
             logger.debug(f"Sleeping for {t}ms")
             time.sleep(t / 1000)
 
-        def led(self, b: bool):
+        def set_led(self, b: bool):
             status_led.value = b
 
         def set_default_delay(self, t: int):

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -409,7 +409,7 @@ try:
                     if line[1] == "1":
                         status_led.value = True
                     if line[1] == "0":
-                        status_led.value = True
+                        status_led.value = False
 
             return out
 

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -1,8 +1,8 @@
-# NOT IMPLEMENTED: BUTTON, $_RANDOM_MIN, $_RANDOM_MAX
+# NOT IMPLEMENTED: BUTTON, ATTACKMODE, $_RANDOM_MIN, $_RANDOM_MAX
 import os
 import digitalio
 import board
-import state
+import microcontroller
 
 print("Main.py: Starting up...")
 # Setup LED
@@ -27,7 +27,7 @@ from adafruit_logging import FileHandler
 
 logger = logging.getLogger("compiler.py")
 logger.setLevel(logging.DEBUG)
-programming_mode = state.programming_mode
+programming_mode = microcontroller.nvm[0] == 1
 
 try:
     LOG_FILE_PATH = "/debug.log"
@@ -405,11 +405,10 @@ try:
                 elif command.startswith("$"):
                     out.append(lambda l=line: self.reassign(l))
 
-                elif command.startswith("LED"):
-                    if line[1] == "1":
-                        status_led.value = True
-                    if line[1] == "0":
-                        status_led.value = False
+                elif command == "LED_ON":
+                    out.append(lambda: self.led(True))
+                elif command == "LED_OFF":
+                    out.append(lambda: self.led(False))
 
             return out
 
@@ -688,6 +687,9 @@ try:
         def delay(self, t: int):
             logger.debug(f"Sleeping for {t}ms")
             time.sleep(t / 1000)
+
+        def led(self, b: bool):
+            status_led.value = b
 
         def set_default_delay(self, t: int):
             self.default_delay = t

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -1,4 +1,4 @@
-# NOT IMPLEMENTED: BUTTON, ATTACKMODE, LED, $_RANDOM_MIN, $_RANDOM_MAX
+# NOT IMPLEMENTED: BUTTON, $_RANDOM_MIN, $_RANDOM_MAX
 import os
 import digitalio
 import board

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -1,5 +1,5 @@
 # NOT IMPLEMENTED: BUTTON, ATTACKMODE, LED, $_RANDOM_MIN, $_RANDOM_MAX
-
+import os
 import digitalio
 import board
 
@@ -7,6 +7,10 @@ print("Main.py: Starting up...")
 # Setup LED
 status_led = digitalio.DigitalInOut(board.LED)
 status_led.direction = digitalio.Direction.OUTPUT
+
+# get envs
+payload_name = os.getenv("PAYLOAD_NAME")
+payload_dir = os.getenv("PAYLOAD_DIRECTORY")
 
 
 def flash_error():
@@ -269,9 +273,8 @@ try:
                     compiled_loop_body = self._compile_block(loop_body_lines)
 
                     # Create a single function that runs the entire loop
-                    loop_func = (
-                        lambda ct=condition_tokens,
-                        body=compiled_loop_body: self._execute_while_loop(ct, body)
+                    loop_func = lambda ct=condition_tokens, body=compiled_loop_body: (
+                        self._execute_while_loop(ct, body)
                     )
                     out.append(loop_func)
                     continue
@@ -722,26 +725,47 @@ try:
         flash_error()
     else:
         from layouts_manager import layouts, kbd, keycodes
+
         print(f"Main.py: Found {len(usb_hid.devices)} HID devices")
         print("Main.py: Keyboard initialized successfully")
-        
+
         # Test keyboard initialization
         kbd.release_all()
         print("Main.py: Keyboard test successful")
 
+    # Prepare payload
+
+    if not payload_dir:
+        payload_dir = "/ducks"
+
+    if not payload_name:
+        print("Main.py: Looking for .ducky files...")
+        files = os.listdir(payload_dir)
+        print(f"Main.py: Files in {payload_dir}: {files}")
+
+        ducky_files = sorted(
+            [
+                f"{payload_dir}/" + f
+                for f in files
+                if (f.endswith(".ducky") or f.endswith(".ducky.txt"))
+                and not f.startswith("._")
+            ]
+        )
+        print(f"Main.py: Found {len(ducky_files)} .ducky file(s): {ducky_files}")
+
+        if ducky_files:
+            payload_path = ducky_files[0]
+        else:
+            payload_path = None
+    else:
+        payload_path = f"{payload_dir}/{payload_name}"
+
     # Main execution
-    print("Main.py: Looking for .ducky files...")
-    files = os.listdir("/ducks")
-    print(f"Main.py: Files in /ducks: {files}")
-    
-    ducky_files = sorted(["/ducks/" + f for f in files if (f.endswith(".ducky") or f.endswith(".ducky.txt")) and not f.startswith("._")])
-    print(f"Main.py: Found {len(ducky_files)} .ducky file(s): {ducky_files}")
-    
-    if ducky_files:
+    if payload_path:
         print(f"Main.py: Creating compiler...")
         compiler = DuckyScriptCompiler(layouts["us"], kbd, keycodes["us"])
         print(f"Main.py: Starting payload execution...")
-        compiler.run(ducky_files[0])
+        compiler.run(payload_path)
     else:
         print("Main.py: ERROR - No .ducky files found in /ducks directory!")
 
@@ -749,6 +773,7 @@ except Exception as e:
     print(f"Main.py: FATAL ERROR: {e}")
     try:
         import traceback
+
         traceback.print_exception(type(e), e, e.__traceback__)
     except:
         pass  # traceback might not be available in CircuitPython

--- a/firmware/settings.toml
+++ b/firmware/settings.toml
@@ -1,0 +1,3 @@
+PAYLOAD_DIRECTORY=/ducks
+PAYLOAD_NAME=test-firmware.ducky
+ATTACK_MODE=storage

--- a/firmware/state.py
+++ b/firmware/state.py
@@ -1,0 +1,1 @@
+programming_mode = False

--- a/firmware/state.py
+++ b/firmware/state.py
@@ -1,1 +1,0 @@
-programming_mode = False


### PR DESCRIPTION
## SD Card Mounting
Mounts SD card at `/sd` using pins from the v1 Hackducky board.
```
spi = busio.SPI(board.GP2, MOSI=board.GP3, MISO=board.GP4)
cs = board.GP5

sd = sdcardio.SDCard(spi, cs)
vfs = storage.VfsFat(sd)
storage.mount(vfs, "/sd")
```

## Attackmode and Payload config through `settings.toml`
Selected payload and storage exposure during an attack can be configured in a `settings.toml` as follows:
```
PAYLOAD_DIRECTORY=/ducks
PAYLOAD_NAME=rickroll.ducky
ATTACK_MODE=storage
```

## LED Usage in Duckyscript
Adds the LED keyword to duckyscripts.
Example of usage:
```
LED_ON # turns on the LED
DELAY 500
LED_OFF # turns off the LED
```